### PR TITLE
Include Design Assurance Level

### DIFF
--- a/org.osate.face2aadl.help/markdown/Translator.md
+++ b/org.osate.face2aadl.help/markdown/Translator.md
@@ -350,6 +350,8 @@ The following describes how UoPs are translated.
 	* The property **FACE::Segment** is set a value based on the type of UoP. If the UoP is a
 	  **face.uop.PlatformSpecificComponent**, then the value is **PSSS**. If the UoP is a
 	  **face.uop.PortableComponent**, then the value is **PCS**.
+	* The **designAssuranceLevel** field is translated into the property **FACE::Design_Assurance_Level**. The possible
+	  values for this property are **A**, **B**, **C**, **D**, and **E**.
 	* If the FACE file was generated using UUIDs, then the property **FACE::UUID** is set to the ID of the
 	  **UnitOfPortability**.
 	* Each **connection** that is a **face.uop.ClientServerConnection** is translated into an event data port
@@ -454,6 +456,7 @@ The following is an example of a translated UoP model:
 	    properties
 	      FACE::Profile => general;
 	      FACE::Segment => PCS;
+		  FACE::Design_Assurance_Level => A;
 	  end Altitude_Sensor;
 	
 	  thread group implementation Altitude_Sensor.impl
@@ -493,6 +496,7 @@ The following is an example of a translated UoP model:
 	    properties
 	      FACE::Profile => general;
 	      FACE::Segment => PCS;
+		  FACE::Design_Assurance_Level => A;
 	  end Autopilot;
 	
 	  thread group implementation Autopilot.impl
@@ -878,6 +882,8 @@ The following describes how UoPs are translated.
 	* The property **FACE::Segment** is set a value based on the type of UoP. If the UoP is a
 	  **face.uop.PlatformSpecificComponent**, then the value is **PSSS**. If the UoP is a
 	  **face.uop.PortableComponent**, then the value is **PCS**.
+	* The **designAssuranceLevel** field is translated into the property **FACE::Design_Assurance_Level**. The possible
+	  values for this property are **A**, **B**, **C**, **D**, and **E**.
 	* If the FACE file was generated using UUIDs, then the property **FACE::UUID** is set to the ID of the
 	  **UnitOfPortability**.
 	* Each **connection** that is a **face.uop.ClientServerConnection** is translated into an event data port
@@ -980,6 +986,7 @@ The following describes how UoPs are translated.
 			properties
 				FACE::Profile => general;
 				FACE::Segment => PCS;
+				FACE::Design_Assurance_Level => A;
 		end Altitude_Sensor;
 		
 		thread group implementation Altitude_Sensor.impl
@@ -1019,6 +1026,7 @@ The following describes how UoPs are translated.
 			properties
 				FACE::Profile => general;
 				FACE::Segment => PCS;
+				FACE::Design_Assurance_Level => A;
 		end Autopilot;
 		
 		thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/compositeTemplateReference/compositeTemplateReference_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/compositeTemplateReference/compositeTemplateReference_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connectedclient/connectedClient_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connectedclient/connectedClient_PSSS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connectedserver/connectedServer_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connectedserver/connectedServer_PSSS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connections/K_connections_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/connections/K_connections_PCS.aadl
@@ -35,6 +35,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent1;
 	
 	thread group implementation PortableComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/DesignAssuranceLevelsTest.java
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/DesignAssuranceLevelsTest.java
@@ -1,0 +1,9 @@
+package org.osate.face2aadl.face30.designAssuranceLevels;
+
+import org.osate.face2aadl.face30.AbstractTranslator30Test;
+
+public class DesignAssuranceLevelsTest extends AbstractTranslator30Test {
+	public DesignAssuranceLevelsTest() {
+		super("designAssuranceLevels", false, true);
+	}
+}

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels.face
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels.face
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<face:ArchitectureModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:face="http://www.opengroup.us/face/3.0" xmlns:platform="http://www.opengroup.us/face/datamodel/platform/3.0" xmlns:uop="http://www.opengroup.us/face/uop/3.0" name="ArchitectureModel1">
+  <dm name="DataModel1">
+    <pdm name="PlatformDataModel1">
+      <element xsi:type="platform:Template" name="Template1" specification="&lt;"/>
+    </pdm>
+  </dm>
+  <um name="UoPModel1">
+    <element xsi:type="uop:PortableComponent" name="PortableComponent1" faceProfile="Security">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:QueuingConnection" name="QueuingConnection1" messageType="//@dm.0/@pdm.0/@element.0" depth="1"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent2" designAssuranceLevel="B" faceProfile="SafetyBase">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC1" messageType="//@dm.0/@pdm.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent3" designAssuranceLevel="C" faceProfile="SafetyExtended">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC2" messageType="//@dm.0/@pdm.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent4" designAssuranceLevel="D" faceProfile="SafetyExtended">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC3" messageType="//@dm.0/@pdm.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent5" designAssuranceLevel="E" faceProfile="SafetyExtended">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC4" messageType="//@dm.0/@pdm.0/@element.0"/>
+    </element>
+  </um>
+</face:ArchitectureModel>

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels_PCS.aadl
@@ -1,0 +1,198 @@
+--Generated from "designAssuranceLevels.face"
+package designAssuranceLevels_PCS
+public
+	with designAssuranceLevels_data_model;
+	with FACE;
+	
+	thread group PortableComponent1
+		features
+			QueuingConnection1: in event data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+				Queue_Size => 1;
+			};
+		properties
+			FACE::Profile => security;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
+	end PortableComponent1;
+	
+	thread group implementation PortableComponent1.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent1.impl;
+	
+	process PortableComponent1_process
+		features
+			QueuingConnection1: in event data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+				Queue_Size => 1;
+			};
+		flows
+			QueuingConnection1_sink: flow sink QueuingConnection1;
+	end PortableComponent1_process;
+	
+	process implementation PortableComponent1_process.impl
+		subcomponents
+			PortableComponent1: thread group PortableComponent1.impl;
+		connections
+			QueuingConnection1_connection: port QueuingConnection1 -> PortableComponent1.QueuingConnection1;
+		flows
+			QueuingConnection1_sink: flow sink QueuingConnection1 -> QueuingConnection1_connection -> PortableComponent1;
+	end PortableComponent1_process.impl;
+	
+	thread group PortableComponent2
+		features
+			SIMC1: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => B;
+	end PortableComponent2;
+	
+	thread group implementation PortableComponent2.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent2.impl;
+	
+	process PortableComponent2_process
+		features
+			SIMC1: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC1_sink: flow sink SIMC1;
+	end PortableComponent2_process;
+	
+	process implementation PortableComponent2_process.impl
+		subcomponents
+			PortableComponent2: thread group PortableComponent2.impl;
+		connections
+			SIMC1_connection: port SIMC1 -> PortableComponent2.SIMC1;
+		flows
+			SIMC1_sink: flow sink SIMC1 -> SIMC1_connection -> PortableComponent2;
+	end PortableComponent2_process.impl;
+	
+	thread group PortableComponent3
+		features
+			SIMC2: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety_extended;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => C;
+	end PortableComponent3;
+	
+	thread group implementation PortableComponent3.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent3.impl;
+	
+	process PortableComponent3_process
+		features
+			SIMC2: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC2_sink: flow sink SIMC2;
+	end PortableComponent3_process;
+	
+	process implementation PortableComponent3_process.impl
+		subcomponents
+			PortableComponent3: thread group PortableComponent3.impl;
+		connections
+			SIMC2_connection: port SIMC2 -> PortableComponent3.SIMC2;
+		flows
+			SIMC2_sink: flow sink SIMC2 -> SIMC2_connection -> PortableComponent3;
+	end PortableComponent3_process.impl;
+	
+	thread group PortableComponent4
+		features
+			SIMC3: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety_extended;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => D;
+	end PortableComponent4;
+	
+	thread group implementation PortableComponent4.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent4.impl;
+	
+	process PortableComponent4_process
+		features
+			SIMC3: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC3_sink: flow sink SIMC3;
+	end PortableComponent4_process;
+	
+	process implementation PortableComponent4_process.impl
+		subcomponents
+			PortableComponent4: thread group PortableComponent4.impl;
+		connections
+			SIMC3_connection: port SIMC3 -> PortableComponent4.SIMC3;
+		flows
+			SIMC3_sink: flow sink SIMC3 -> SIMC3_connection -> PortableComponent4;
+	end PortableComponent4_process.impl;
+	
+	thread group PortableComponent5
+		features
+			SIMC4: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety_extended;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => E;
+	end PortableComponent5;
+	
+	thread group implementation PortableComponent5.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent5.impl;
+	
+	process PortableComponent5_process
+		features
+			SIMC4: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC4_sink: flow sink SIMC4;
+	end PortableComponent5_process;
+	
+	process implementation PortableComponent5_process.impl
+		subcomponents
+			PortableComponent5: thread group PortableComponent5.impl;
+		connections
+			SIMC4_connection: port SIMC4 -> PortableComponent5.SIMC4;
+		flows
+			SIMC4_sink: flow sink SIMC4 -> SIMC4_connection -> PortableComponent5;
+	end PortableComponent5_process.impl;
+end designAssuranceLevels_PCS;

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels_data_model.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/designAssuranceLevels/designAssuranceLevels_data_model.aadl
@@ -1,0 +1,13 @@
+--Generated from "designAssuranceLevels.face"
+package designAssuranceLevels_data_model
+public
+	with FACE;
+	
+	data Template1_Platform
+		properties
+			FACE::Realization_Tier => platform;
+	end Template1_Platform;
+	
+	data implementation Template1_Platform.impl
+	end Template1_Platform.impl;
+end designAssuranceLevels_data_model;

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/duplicateNodeNames/duplicateNodeNames_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/duplicateNodeNames/duplicateNodeNames_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -52,6 +53,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filtering/filtering_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filtering/filtering_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filtering/filtering_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filtering/filtering_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringNoFlows/filteringNoFlows_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringNoFlows/filteringNoFlows_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringNoFlows/filteringNoFlows_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringNoFlows/filteringNoFlows_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringPlatformOnly/filteringPlatformOnly_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringPlatformOnly/filteringPlatformOnly_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringPlatformOnly/filteringPlatformOnly_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/filteringPlatformOnly/filteringPlatformOnly_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/miscUoP/miscUoP_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/miscUoP/miscUoP_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => security;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent1;
 	
 	thread group implementation PortableComponent1.impl
@@ -51,6 +52,7 @@ public
 		properties
 			FACE::Profile => safety;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent2;
 	
 	thread group implementation PortableComponent2.impl
@@ -88,6 +90,7 @@ public
 		properties
 			FACE::Profile => safety_extended;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent3;
 	
 	thread group implementation PortableComponent3.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/noFlows/noFlows_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/noFlows/noFlows_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -48,6 +49,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/threads/threads_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/threads/threads_PCS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent1;
 	
 	thread group implementation PortableComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/translatorDemo/TranslatorDemo_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/translatorDemo/TranslatorDemo_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -52,6 +53,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/uuid/uuid_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/uuid/uuid_PCS.aadl
@@ -17,6 +17,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 			FACE::UUID => "_AluBQGRREeiJQvh_fVqImg";
 	end PortableComponent1;
 	

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/uuidPlatformOnly/uuidPlatformOnly_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/uuidPlatformOnly/uuidPlatformOnly_PCS.aadl
@@ -17,6 +17,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 			FACE::UUID => "_AluBQGRREeiJQvh_fVqImg";
 	end PortableComponent1;
 	

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/viewSink/viewSink_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/viewSink/viewSink_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/viewSource/viewSource_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face30/viewSource/viewSource_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/compositeTemplateReference/compositeTemplateReference_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/compositeTemplateReference/compositeTemplateReference_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connectedclient/connectedClient_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connectedclient/connectedClient_PSSS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connectedserver/connectedServer_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connectedserver/connectedServer_PSSS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connections/K_connections_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/connections/K_connections_PCS.aadl
@@ -35,6 +35,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent1;
 	
 	thread group implementation PortableComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/DesignAssuranceLevelsTest.java
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/DesignAssuranceLevelsTest.java
@@ -1,0 +1,9 @@
+package org.osate.face2aadl.face31.designAssuranceLevels;
+
+import org.osate.face2aadl.face31.AbstractTranslator31Test;
+
+public class DesignAssuranceLevelsTest extends AbstractTranslator31Test {
+	public DesignAssuranceLevelsTest() {
+		super("designAssuranceLevels", false, true);
+	}
+}

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels.face
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels.face
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<face:ArchitectureModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:face="http://www.opengroup.us/face/3.1" xmlns:uop="http://www.opengroup.us/face/uop/3.1" name="ArchitectureModel1">
+  <um name="UoPModel1">
+    <element xsi:type="uop:Template" name="Template1" specification="&lt;"/>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent1" faceProfile="Security">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:QueuingConnection" name="QueuingConnection1" messageType="//@um.0/@element.0" depth="1"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent2" designAssuranceLevel="B" faceProfile="SafetyBase">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC1" messageType="//@um.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent3" designAssuranceLevel="C" faceProfile="SafetyExtended">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC2" messageType="//@um.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent4" designAssuranceLevel="D" faceProfile="SafetyBase">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC3" messageType="//@um.0/@element.0"/>
+    </element>
+    <element xsi:type="uop:PortableComponent" name="PortableComponent5" designAssuranceLevel="E" faceProfile="SafetyBase">
+      <thread/>
+      <memoryRequirements/>
+      <connection xsi:type="uop:SingleInstanceMessageConnection" name="SIMC4" messageType="//@um.0/@element.0"/>
+    </element>
+  </um>
+</face:ArchitectureModel>

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels_PCS.aadl
@@ -1,12 +1,12 @@
---Generated from "miscUoP.face"
-package miscUoP_PCS
+--Generated from "designAssuranceLevels.face"
+package designAssuranceLevels_PCS
 public
+	with designAssuranceLevels_data_model;
 	with FACE;
-	with miscUoP_data_model;
 	
 	thread group PortableComponent1
 		features
-			QueuingConnection1: in event data port miscUoP_data_model::Template1_Platform.impl {
+			QueuingConnection1: in event data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 				Queue_Size => 1;
 			};
@@ -27,7 +27,7 @@ public
 	
 	process PortableComponent1_process
 		features
-			QueuingConnection1: in event data port miscUoP_data_model::Template1_Platform.impl {
+			QueuingConnection1: in event data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 				Queue_Size => 1;
 			};
@@ -46,13 +46,13 @@ public
 	
 	thread group PortableComponent2
 		features
-			SIMC1: in data port miscUoP_data_model::Template1_Platform.impl {
+			SIMC1: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 			};
 		properties
 			FACE::Profile => safety;
 			FACE::Segment => PCS;
-			FACE::Design_Assurance_Level => A;
+			FACE::Design_Assurance_Level => B;
 	end PortableComponent2;
 	
 	thread group implementation PortableComponent2.impl
@@ -66,7 +66,7 @@ public
 	
 	process PortableComponent2_process
 		features
-			SIMC1: in data port miscUoP_data_model::Template1_Platform.impl {
+			SIMC1: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 			};
 		flows
@@ -84,13 +84,13 @@ public
 	
 	thread group PortableComponent3
 		features
-			SIMC2: in data port miscUoP_data_model::Template1_Platform.impl {
+			SIMC2: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 			};
 		properties
 			FACE::Profile => safety_extended;
 			FACE::Segment => PCS;
-			FACE::Design_Assurance_Level => A;
+			FACE::Design_Assurance_Level => C;
 	end PortableComponent3;
 	
 	thread group implementation PortableComponent3.impl
@@ -104,7 +104,7 @@ public
 	
 	process PortableComponent3_process
 		features
-			SIMC2: in data port miscUoP_data_model::Template1_Platform.impl {
+			SIMC2: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
 				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
 			};
 		flows
@@ -119,4 +119,80 @@ public
 		flows
 			SIMC2_sink: flow sink SIMC2 -> SIMC2_connection -> PortableComponent3;
 	end PortableComponent3_process.impl;
-end miscUoP_PCS;
+	
+	thread group PortableComponent4
+		features
+			SIMC3: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => D;
+	end PortableComponent4;
+	
+	thread group implementation PortableComponent4.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent4.impl;
+	
+	process PortableComponent4_process
+		features
+			SIMC3: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC3_sink: flow sink SIMC3;
+	end PortableComponent4_process;
+	
+	process implementation PortableComponent4_process.impl
+		subcomponents
+			PortableComponent4: thread group PortableComponent4.impl;
+		connections
+			SIMC3_connection: port SIMC3 -> PortableComponent4.SIMC3;
+		flows
+			SIMC3_sink: flow sink SIMC3 -> SIMC3_connection -> PortableComponent4;
+	end PortableComponent4_process.impl;
+	
+	thread group PortableComponent5
+		features
+			SIMC4: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		properties
+			FACE::Profile => safety;
+			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => E;
+	end PortableComponent5;
+	
+	thread group implementation PortableComponent5.impl
+		subcomponents
+			thread0: thread {
+				Compute_Execution_Time => 0 sec .. 0 sec;
+				Period => 0 sec;
+				Priority => 0;
+			};
+	end PortableComponent5.impl;
+	
+	process PortableComponent5_process
+		features
+			SIMC4: in data port designAssuranceLevels_data_model::Template1_Platform.impl {
+				Input_Rate => [Value_Range => 0.0 .. 0.0; Rate_Unit => PerSecond;];
+			};
+		flows
+			SIMC4_sink: flow sink SIMC4;
+	end PortableComponent5_process;
+	
+	process implementation PortableComponent5_process.impl
+		subcomponents
+			PortableComponent5: thread group PortableComponent5.impl;
+		connections
+			SIMC4_connection: port SIMC4 -> PortableComponent5.SIMC4;
+		flows
+			SIMC4_sink: flow sink SIMC4 -> SIMC4_connection -> PortableComponent5;
+	end PortableComponent5_process.impl;
+end designAssuranceLevels_PCS;

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels_data_model.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/designAssuranceLevels/designAssuranceLevels_data_model.aadl
@@ -1,0 +1,13 @@
+--Generated from "designAssuranceLevels.face"
+package designAssuranceLevels_data_model
+public
+	with FACE;
+	
+	data Template1_Platform
+		properties
+			FACE::Realization_Tier => platform;
+	end Template1_Platform;
+	
+	data implementation Template1_Platform.impl
+	end Template1_Platform.impl;
+end designAssuranceLevels_data_model;

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/duplicateNodeNames/duplicateNodeNames_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/duplicateNodeNames/duplicateNodeNames_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -52,6 +53,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filtering/filtering_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filtering/filtering_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filtering/filtering_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filtering/filtering_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringNoFlows/filteringNoFlows_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringNoFlows/filteringNoFlows_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringNoFlows/filteringNoFlows_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringNoFlows/filteringNoFlows_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringPlatformOnly/filteringPlatformOnly_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringPlatformOnly/filteringPlatformOnly_PCS.aadl
@@ -15,6 +15,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end UsedPCS1;
 	
 	thread group implementation UsedPCS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringPlatformOnly/filteringPlatformOnly_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/filteringPlatformOnly/filteringPlatformOnly_PSSS.aadl
@@ -19,6 +19,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end SelectedPSSS1;
 	
 	thread group implementation SelectedPSSS1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/noFlows/noFlows_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/noFlows/noFlows_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -48,6 +49,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/threads/threads_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/threads/threads_PCS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end PortableComponent1;
 	
 	thread group implementation PortableComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/translatorDemo/TranslatorDemo_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/translatorDemo/TranslatorDemo_PCS.aadl
@@ -13,6 +13,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Altitude_Sensor;
 	
 	thread group implementation Altitude_Sensor.impl
@@ -52,6 +53,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 	end Autopilot;
 	
 	thread group implementation Autopilot.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/uuid/uuid_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/uuid/uuid_PCS.aadl
@@ -17,6 +17,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 			FACE::UUID => "_N3sIMK2MEe26NcS3vZp1iQ";
 	end PortableComponent1;
 	

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/uuidPlatformOnly/uuidPlatformOnly_PCS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/uuidPlatformOnly/uuidPlatformOnly_PCS.aadl
@@ -17,6 +17,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PCS;
+			FACE::Design_Assurance_Level => A;
 			FACE::UUID => "_N3sIMK2MEe26NcS3vZp1iQ";
 	end PortableComponent1;
 	

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/viewSink/viewSink_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/viewSink/viewSink_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/viewSource/viewSource_PSSS.aadl
+++ b/org.osate.face2aadl.tests/src/org/osate/face2aadl/face31/viewSource/viewSource_PSSS.aadl
@@ -12,6 +12,7 @@ public
 		properties
 			FACE::Profile => general;
 			FACE::Segment => PSSS;
+			FACE::Design_Assurance_Level => A;
 	end PlatformSpecificComponent1;
 	
 	thread group implementation PlatformSpecificComponent1.impl

--- a/org.osate.face2aadl/resources/FACE.aadl
+++ b/org.osate.face2aadl/resources/FACE.aadl
@@ -18,4 +18,5 @@ property set FACE is
 	
 	Profile: enumeration (security, safety_extended, safety, general) applies to (all);
 	Segment: enumeration (PSSS, PCS, IOSS, OSS, TSS) applies to (all);
+	Design_Assurance_Level: enumeration (A, B, C, D, E) applies to (thread group);
 end FACE;

--- a/org.osate.face2aadl/src/org/osate/face2aadl/logic30/UoPTranslator.xtend
+++ b/org.osate.face2aadl/src/org/osate/face2aadl/logic30/UoPTranslator.xtend
@@ -106,6 +106,7 @@ package class UoPTranslator {
 				properties
 					FACE::Profile => «profile»;
 					FACE::Segment => «segment»;
+					FACE::Design_Assurance_Level => «component.designAssuranceLevel»;
 					«translateUUID(component)»
 			end «name»;
 			

--- a/org.osate.face2aadl/src/org/osate/face2aadl/logic31/UoPTranslator.xtend
+++ b/org.osate.face2aadl/src/org/osate/face2aadl/logic31/UoPTranslator.xtend
@@ -106,6 +106,7 @@ package class UoPTranslator {
 				properties
 					FACE::Profile => «profile»;
 					FACE::Segment => «segment»;
+					FACE::Design_Assurance_Level => «component.designAssuranceLevel»;
 					«translateUUID(component)»
 			end «name»;
 			


### PR DESCRIPTION
Each UoP's `designAssuranceLevel` field is translated into the AADL property `FACE::Design_Assurance_Level`. This applies to both FACE 3.0 and FACE 3.1 models.